### PR TITLE
Update step repo url from bitrise-io org to bitrise-steplib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Activate SSH key (RSA private key)
 
-[![Step changelog](https://shields.io/github/v/release/bitrise-io/steps-activate-ssh-key?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-io/steps-activate-ssh-key/releases)
+[![Step changelog](https://shields.io/github/v/release/bitrise-steplib/steps-activate-ssh-key?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/steps-activate-ssh-key/releases)
 
 Setup the SSH Key to use with the current workflow
 
@@ -63,7 +63,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 ## 🙋 Contributing
 
-We welcome [pull requests](https://github.com/bitrise-io/steps-activate-ssh-key/pulls) and [issues](https://github.com/bitrise-io/steps-activate-ssh-key/issues) against this repository.
+We welcome [pull requests](https://github.com/bitrise-steplib/steps-activate-ssh-key/pulls) and [issues](https://github.com/bitrise-steplib/steps-activate-ssh-key/issues) against this repository.
 
 For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
 

--- a/step.yml
+++ b/step.yml
@@ -26,9 +26,9 @@ description: |-
   ### Related Steps
 
   - [Git Clone Repository](https://www.bitrise.io/integrations/steps/git-clone)
-website: https://github.com/bitrise-io/steps-activate-ssh-key
-source_code_url: https://github.com/bitrise-io/steps-activate-ssh-key
-support_url: https://github.com/bitrise-io/steps-activate-ssh-key/issues
+website: https://github.com/bitrise-steplib/steps-activate-ssh-key
+source_code_url: https://github.com/bitrise-steplib/steps-activate-ssh-key
+support_url: https://github.com/bitrise-steplib/steps-activate-ssh-key/issues
 host_os_tags:
 - osx-10.9
 type_tags:


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _NO_ [version update](https://semver.org/)

### Context

Update step repo url from `bitrise-io` org to `bitrise-steplib`.

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
